### PR TITLE
Fix crash, memory leak and python3 compatibility.

### DIFF
--- a/WindowsNativeWifiApi.py
+++ b/WindowsNativeWifiApi.py
@@ -19,6 +19,8 @@
 # Author: Andres Blanco (6e726d)     <6e726d@gmail.com>
 #
 
+from compat import iteritems
+
 from ctypes import *
 
 from comtypes import GUID
@@ -62,10 +64,10 @@ DOT11_MAC_ADDRESS = c_ubyte * 6
 # type.
 DOT11_BSS_TYPE = c_uint
 DOT11_BSS_TYPE_DICT_KV = {1: "dot11_BSS_type_infrastructure",
-                       2: "dot11_BSS_type_independent",
-                       3: "dot11_BSS_type_any"}
+                          2: "dot11_BSS_type_independent",
+                          3: "dot11_BSS_type_any"}
 DOT11_BSS_TYPE_DICT_VK = { v: k for k, v in
-        DOT11_BSS_TYPE_DICT_KV.iteritems() }
+        iteritems(DOT11_BSS_TYPE_DICT_KV) }
 
 # The DOT11_PHY_TYPE enumeration defines an 802.11 PHY and media type.
 DOT11_PHY_TYPE = c_uint
@@ -641,7 +643,7 @@ WLAN_CONNECTION_MODE_KV = {0: "wlan_connection_mode_profile",
                            4: "wlan_connection_mode_auto",
                            5: "wlan_connection_mode_invalid"}
 WLAN_CONNECTION_MODE_VK = { v: k for k, v in
-        WLAN_CONNECTION_MODE_KV.iteritems() }
+        iteritems(WLAN_CONNECTION_MODE_KV) }
 
 class NDIS_OBJECT_HEADER(Structure):
     """

--- a/WindowsNativeWifiApi.py
+++ b/WindowsNativeWifiApi.py
@@ -451,7 +451,7 @@ def WlanEnumInterfaces(hClientHandle):
     return wlan_ifaces
 
 
-def WlanScan(hClientHandle, pInterfaceGuid, ssid=""):
+def WlanScan(hClientHandle, pInterfaceGuid, ssid=b""):
     """
         The WlanScan function requests a scan for available networks on the
         indicated interface.

--- a/WindowsWifi.py
+++ b/WindowsWifi.py
@@ -241,14 +241,18 @@ def getWirelessProfiles(wireless_interface):
     num = profile_list.contents.NumberOfItems
     profile_info_pointer = addressof(profile_list.contents.ProfileInfo)
     xml_data = None  # safety: there may be no profiles
-    for profile in (data_type * num).from_address(profile_info_pointer):
-        xml_data = WlanGetProfile(handle,
-                                  wireless_interface.guid,
-                                  profile.ProfileName)
-        profiles.append(WirelessProfile(profile, xml_data.value))
-    WlanFreeMemory(xml_data)
-    WlanFreeMemory(profile_list)
-    WlanCloseHandle(handle)
+    try:
+        for profile in (data_type * num).from_address(profile_info_pointer):
+            try:
+                xml_data = WlanGetProfile(handle,
+                                          wireless_interface.guid,
+                                          profile.ProfileName)
+                profiles.append(WirelessProfile(profile, xml_data.value))
+            finally:
+                WlanFreeMemory(xml_data)
+    finally:
+        WlanFreeMemory(profile_list)
+        WlanCloseHandle(handle)
     return profiles
 
 

--- a/WindowsWifi.py
+++ b/WindowsWifi.py
@@ -201,7 +201,6 @@ def getWirelessNetworkBssList(wireless_interface):
 def getWirelessAvailableNetworkList(wireless_interface):
     """Returns a list of WirelessNetwork objects based on the wireless
        networks availables."""
-    networks = []
     handle = WlanOpenHandle()
     network_list = WlanGetAvailableNetworkList(handle, wireless_interface.guid)
     # Handle the WLAN_AVAILABLE_NETWORK_LIST pointer to get a list of
@@ -209,10 +208,9 @@ def getWirelessAvailableNetworkList(wireless_interface):
     data_type = network_list.contents.Network._type_
     num = network_list.contents.NumberOfItems
     network_pointer = addressof(network_list.contents.Network)
-    networks_list = (data_type * num).from_address(network_pointer)
-    for network in networks_list:
-        networks.append(WirelessNetwork(network))
-    WlanFreeMemory(networks_list)
+    networks = [ WirelessNetwork(network)
+                 for network in (data_type * num).from_address(network_pointer) ]
+    WlanFreeMemory(network_list)
     WlanCloseHandle(handle)
     return networks
 

--- a/WindowsWifi.py
+++ b/WindowsWifi.py
@@ -205,13 +205,15 @@ def getWirelessAvailableNetworkList(wireless_interface):
     network_list = WlanGetAvailableNetworkList(handle, wireless_interface.guid)
     # Handle the WLAN_AVAILABLE_NETWORK_LIST pointer to get a list of
     # WLAN_AVAILABLE_NETWORK structures.
-    data_type = network_list.contents.Network._type_
-    num = network_list.contents.NumberOfItems
-    network_pointer = addressof(network_list.contents.Network)
-    networks = [ WirelessNetwork(network)
-                 for network in (data_type * num).from_address(network_pointer) ]
-    WlanFreeMemory(network_list)
-    WlanCloseHandle(handle)
+    try:
+        data_type = network_list.contents.Network._type_
+        num = network_list.contents.NumberOfItems
+        network_pointer = addressof(network_list.contents.Network)
+        networks = [ WirelessNetwork(network)
+                     for network in (data_type * num).from_address(network_pointer) ]
+    finally:
+        WlanFreeMemory(network_list)
+        WlanCloseHandle(handle)
     return networks
 
 

--- a/WindowsWifi.py
+++ b/WindowsWifi.py
@@ -22,6 +22,7 @@
 from ctypes import *
 from comtypes import GUID
 from WindowsNativeWifiApi import *
+from compat import indexbytes
 
 NULL = None
 
@@ -102,7 +103,7 @@ class WirelessNetworkBss(object):
         self.__process_information_elements2()
 
     def __process_information_elements(self, bss_entry):
-        self.raw_information_elements = ""
+        self.raw_information_elements = b""
         bss_entry_pointer = addressof(bss_entry)
         ie_offset = bss_entry.IeOffset
         data_type = (c_char * bss_entry.IeSize)
@@ -115,10 +116,10 @@ class WirelessNetworkBss(object):
         self.information_elements = []
         aux = self.raw_information_elements
         index = 0
-        while(index < len(aux) - MINIMAL_IE_SIZE):
-            eid = ord(aux[index])
+        while index < len(aux) - MINIMAL_IE_SIZE:
+            eid = indexbytes(aux, index)
             index += 1
-            length = ord(aux[index])
+            length = indexbytes(aux, index)
             index += 1
             body = aux[index:index + length]
             index += length

--- a/WindowsWifi.py
+++ b/WindowsWifi.py
@@ -240,15 +240,14 @@ def getWirelessProfiles(wireless_interface):
     data_type = profile_list.contents.ProfileInfo._type_
     num = profile_list.contents.NumberOfItems
     profile_info_pointer = addressof(profile_list.contents.ProfileInfo)
-    profiles_list = (data_type * num).from_address(profile_info_pointer)
     xml_data = None  # safety: there may be no profiles
-    for profile in profiles_list:
+    for profile in (data_type * num).from_address(profile_info_pointer):
         xml_data = WlanGetProfile(handle,
                                   wireless_interface.guid,
                                   profile.ProfileName)
         profiles.append(WirelessProfile(profile, xml_data.value))
     WlanFreeMemory(xml_data)
-    WlanFreeMemory(profiles_list)
+    WlanFreeMemory(profile_list)
     WlanCloseHandle(handle)
     return profiles
 

--- a/compat.py
+++ b/compat.py
@@ -9,3 +9,10 @@ try:
     iteritems = dict.iteritems
 except AttributeError:
     iteritems = dict.items
+
+if PY2:
+    def indexbytes(buf, index):
+        return ord(buf[index])
+else:
+    def indexbytes(buf, index):
+        return buf[index]

--- a/compat.py
+++ b/compat.py
@@ -1,0 +1,11 @@
+import sys
+
+#: True if Python 2 intepreter is used
+PY2 = sys.version_info[0] == 2
+PY3 = not PY2
+
+
+try:
+    iteritems = dict.iteritems
+except AttributeError:
+    iteritems = dict.items

--- a/examples/list_available_networks.py
+++ b/examples/list_available_networks.py
@@ -19,17 +19,18 @@
 # Author: Andres Blanco (6e726d) <6e726d@gmail.com>
 #
 
+from __future__ import print_function
 from WindowsWifi import getWirelessInterfaces
 from WindowsWifi import getWirelessAvailableNetworkList
 
 if __name__ == "__main__":
     ifaces = getWirelessInterfaces()
     for iface in ifaces:
-        print iface
+        print(iface)
         guid = iface.guid
         networks = getWirelessAvailableNetworkList(iface)
-        print ""
+        print("")
         for network in networks:
-            print network
-            print "-" * 20
-        print ""
+            print(network)
+            print("-" * 20)
+        print("")

--- a/examples/list_networks_bss.py
+++ b/examples/list_networks_bss.py
@@ -19,17 +19,18 @@
 # Author: Andres Blanco (6e726d) <6e726d@gmail.com>
 #
 
+from __future__ import print_function
 from WindowsWifi import getWirelessInterfaces
 from WindowsWifi import getWirelessNetworkBssList
 
 if __name__ == "__main__":
     ifaces = getWirelessInterfaces()
     for iface in ifaces:
-        print iface
+        print(iface)
         guid = iface.guid
         bsss = getWirelessNetworkBssList(iface)
-        print ""
+        print("")
         for bss in bsss:
-            print bss
-            print "-" * 20
-        print ""
+            print(bss)
+            print("-" * 20)
+        print("")

--- a/examples/list_profile.py
+++ b/examples/list_profile.py
@@ -19,17 +19,18 @@
 # Author: Andres Blanco (6e726d) <6e726d@gmail.com>
 #
 
+from __future__ import print_function
 from WindowsWifi import getWirelessInterfaces
 from WindowsWifi import getWirelessProfiles
 
 if __name__ == "__main__":
     ifaces = getWirelessInterfaces()
     for iface in ifaces:
-        print iface
+        print(iface)
         guid = iface.guid
         profiles = getWirelessProfiles(iface)
-        print ""
+        print("")
         for profile in profiles:
-            print profile
-            print "-" * 20
-        print ""
+            print(profile)
+            print("-" * 20)
+        print("")

--- a/tests/WindowsNativeWifiApiTests.py
+++ b/tests/WindowsNativeWifiApiTests.py
@@ -59,7 +59,7 @@ class TestWindowsNativeWifiApi(unittest.TestCase):
         msg = "We expect at least one wireless interface."
         self.assertGreaterEqual(len(wlan_iface_info_list), 0, msg)
         for wlan_iface_info in wlan_iface_info_list:
-            WlanScan(handle, wlan_iface_info.InterfaceGuid, "test")
+            WlanScan(handle, wlan_iface_info.InterfaceGuid, b"test")
         WlanFreeMemory(wlan_ifaces)
         WlanCloseHandle(handle)
 


### PR DESCRIPTION
The crash is due to mistyped variable name (eg: `WlanFreeMemory(networks_list)` vs `WlanFreeMemory(network_list)`).
